### PR TITLE
Update sockjs-erlang

### DIFF
--- a/package.mk
+++ b/package.mk
@@ -2,14 +2,12 @@ APP_NAME:=sockjs
 DEPS:=cowboy-wrapper
 
 UPSTREAM_GIT:=https://github.com/rabbitmq/sockjs-erlang.git
-UPSTREAM_REVISION:=10169681f77432beab6d82bfcb7b426d755f5fea
+UPSTREAM_REVISION:=99fd95329daa6fde1c553edd90921bee8472391b
 RETAIN_ORIGINAL_VERSION:=true
 WRAPPER_PATCHES:=
 
 ORIGINAL_APP_FILE:=$(CLONE_DIR)/src/$(APP_NAME).app.src
 DO_NOT_GENERATE_APP_FILE=true
-
-ERLC_OPTS:=$(ERLC_OPTS) -D no_specs
 
 define construct_app_commands
 	cp $(CLONE_DIR)/LICENSE-* $(APP_DIR)


### PR DESCRIPTION
No need to pass `-Dno_specs`, this macro is unused.

References #4.
